### PR TITLE
fix(interrupts): activate interrupt masking on AArch64

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -90,15 +90,19 @@ mod imp {
     pub type Flags = u64;
     pub type AtomicFlags = core::sync::atomic::AtomicU64;
 
-    pub const DISABLE: u64 = 0;
+    /// Set the `A`, `I`, and `F` bit for _masking_ interrupts.
+    pub const DISABLE: u64 = 0b111000000;
 
     #[inline]
     pub fn get() -> u64 {
-        DAIF.get()
+        // Return only the relevant bits
+        DAIF.get() & DISABLE
     }
 
     #[inline]
     pub fn set(value: u64) {
+        // Set only the relevant bits
+        let value = (DAIF.get() & !DISABLE) | value;
         DAIF.set(value);
     }
 }


### PR DESCRIPTION
Found by @egrimley-arm.

This will fix https://github.com/hermit-os/kernel/issues/846 once it lands in the kernel.

The issue was that ones _mask_ interrupts, not disable them.

Incidentally, the kernel got this right: [hermit-os/kernel/src/arch/aarch64/kernel/interrupts.rs#L58-L95](https://github.com/hermit-os/kernel/blob/4f08d143d70a7a1ed605c164ffdd29379698c05c/src/arch/aarch64/kernel/interrupts.rs#L58-L95)